### PR TITLE
Extend Redix config to support all start_link/1 options

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 [![Hex.pm](https://img.shields.io/hexpm/v/guardian_redis.svg)](https://hex.pm/packages/guardian_redis)
 ![Build Status](https://github.com/alexfilatov/guardian_redis/workflows/Continuous%20Integration/badge.svg)
 
-Redis repository for Guardian DB. 
+Redis repository for Guardian DB.
 
 ## Installation
 
-You can use `GuardianRedis` in case you use [Guardian](https://github.com/ueberauth/guardian) library for authentication 
-and [Guardian.DB](https://github.com/ueberauth/guardian_db) library for JWT tokens persistence.  
+You can use `GuardianRedis` in case you use [Guardian](https://github.com/ueberauth/guardian) library for authentication
+and [Guardian.DB](https://github.com/ueberauth/guardian_db) library for JWT tokens persistence.
 
 If [available in Hex](https://hex.pm/docs/publish), the package can be installed
 by adding `guardian_redis` to your list of dependencies in `mix.exs`:
@@ -24,7 +24,7 @@ end
 
 ## Configuration
 
-All you need to install Guardian DB as per [Guardian.DB README](https://github.com/ueberauth/guardian_db#readme) 
+All you need to install Guardian DB as per [Guardian.DB README](https://github.com/ueberauth/guardian_db#readme)
 and just use `GuardianRedis.Repo` as a `repo` in settings.
 
 ```elixir
@@ -41,7 +41,7 @@ defmodule MyApp.Application do
 
   # ...
 
-  defp my_app_otp_apps() do
+  defp my_app_otp_apps do
     children = [
       MyApp.Repo,
       GuardianRedis.Redix
@@ -59,12 +59,14 @@ config :guardian_redis, :redis,
   pool_size: 10
 ```
 
+More options are available as described in `GuardianRedis.Redix`.
+
 
 ## Implement Guardian.DB repo for a different storage
 
-Initially, Guardian.DB was aimed to store and operate JWT tokens in a PostgreSQL database. 
+Initially, Guardian.DB was aimed to store and operate JWT tokens in a PostgreSQL database.
 Sometimes round trip to Postgres database is expensive so this is why this Redis repo was born.
-In case you want to implement a possibility for Guardian.DB to use different storage, e.g. ETS (or MySQL), 
+In case you want to implement a possibility for Guardian.DB to use different storage, e.g. ETS (or MySQL),
 you need to implement `Guardian.DB.Adapter` behavior. Thanks to [@aleDsz](https://github.com/aleDsz) it's quite simple:
 https://github.com/ueberauth/guardian_db/blob/master/lib/guardian/db/adapter.ex
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -11,5 +11,5 @@ config :guardian, Guardian.DB,
 
 config :guardian_redis, :redis,
   host: System.get_env("REDIS_HOST", "127.0.0.1"),
-  port: System.get_env("REDIS_PORT", "6379"),
-  pool_size: System.get_env("REDIS_POOL_SIZE", "1")
+  port: String.to_integer(System.get_env("REDIS_PORT", "6379")),
+  pool_size: String.to_integer(System.get_env("REDIS_POOL_SIZE", "1"))

--- a/lib/adapter.ex
+++ b/lib/adapter.ex
@@ -12,7 +12,6 @@ defmodule Guardian.DB.Adapter do
   @typep schema_or_changeset :: schema() | changeset()
   @typep queryable :: query() | schema()
   @typep opts :: keyword()
-  @typep id :: pos_integer() | binary() | Ecto.UUID.t()
 
   @doc """
   Retrieves JWT token

--- a/lib/redix.ex
+++ b/lib/redix.ex
@@ -1,21 +1,41 @@
 defmodule GuardianRedis.Redix do
   @moduledoc """
-    Redix module
+  Redix module.
+
+  ### Configuration
+  Configuration options are the same as in `Redix.start_link/1`, except for
+  `pool_size`, `name_prefix`, and `name`.
+
+  - `pool_size` - determines how many Redix connections are created; defaults to `1`
+  - `name_prefix` - the prefix used in `name`; defaults to `"redix"`
+
+  The `name` option is overwritten based on the given `name_prefix` and `pool_size`.
+  In the case of the example below, `name` would be `:g_redis_0` for the first
+  Redis connection, and `:g_redis_1` for the second.
+
+  ```
+  config :guardian_redis, :redis,
+    host: "127.0.0.1",
+    port: 6379,
+    pool_size: 2,
+    name_prefix: "g_redis"
+  ```
   """
-  @default_redis_host "127.0.0.1"
-  @default_redis_port 6379
+  @default_redis_name_prefix "redix"
   @default_redis_pool_size 1
 
   @doc """
   Specs for the Redix connections.
   """
   def child_spec(_args) do
+    config = Keyword.drop(redis_config(), [:pool_size, :name_prefix, :name])
+    name_prefix = name_prefix()
+
     children =
       for index <- 0..(pool_size() - 1) do
-        Supervisor.child_spec(
-          {Redix, name: :"redix_#{index}", host: redis_host(), port: redis_port()},
-          id: {Redix, index}
-        )
+        args = Keyword.put(config, :name, :"#{name_prefix}_#{index}")
+
+        Supervisor.child_spec({Redix, args}, id: {Redix, index})
       end
 
     %{
@@ -43,24 +63,19 @@ defmodule GuardianRedis.Redix do
     Redix.command(:"redix_#{random_index()}", command_params)
   end
 
-  defp redis_host do
-    redis_config()[:host] || @default_redis_host
-  end
-
-  defp redis_port do
-    # casting integer port value to String in case port value comes from ENV
-    ("#{redis_config()[:port]}" || "#{@default_redis_port}") |> String.to_integer()
+  defp random_index do
+    Enum.random(0..(pool_size() - 1))
   end
 
   defp pool_size do
-    "#{redis_config()[:pool_size] || @default_redis_pool_size}" |> String.to_integer()
+    Keyword.get(redis_config(), :pool_size, @default_redis_pool_size)
+  end
+
+  defp name_prefix do
+    Keyword.get(redis_config(), :name_prefix, @default_redis_name_prefix)
   end
 
   defp redis_config do
-    Application.get_env(:guardian_redis, :redis)
-  end
-
-  defp random_index() do
-    Enum.random(0..(pool_size() - 1))
+    Application.get_env(:guardian_redis, :redis, [])
   end
 end

--- a/lib/repo.ex
+++ b/lib/repo.ex
@@ -67,7 +67,7 @@ defmodule GuardianRedis.Repo do
   @spec delete_all(
           queryable :: Ecto.Queryable.t(),
           opts :: Keyword.t()
-        ) :: {integer(), nil | [term()]}
+        ) :: {integer(), :ok}
   def delete_all(query, _opts \\ []) do
     set_name = query |> sub_elem() |> set_name()
 


### PR DESCRIPTION
### Added
- support for all configuration options of Redix (except for name)
- support for `name_prefix` config
### Fixed
- type spec of `Repo.delete_all/2`
- removed unused ID type
### Breaking
- `port` and `pool_size` have to be integers now